### PR TITLE
get screenshots and output to html

### DIFF
--- a/controllers/images/capture_shot.js
+++ b/controllers/images/capture_shot.js
@@ -1,8 +1,47 @@
+//capture_event を受け取り，そのページのスクリーンショットを取得
+
+//スクリーンショット取得上限数
+var storage_limit = 3;
+
+//get_capture_event.js からのイベントの取得
+chrome.runtime.onMessage.addListener(
+    function(request, sender, callback) {
+        if(request.message == "capture_event"){
+            //スクリーンショットの取得
+            capture_shot();
+        }
+        return true;
+    }
+);
+
+//スクリーンショットを取るurlの発見
 function capture_shot(){
+    var url
+    //現在 (lastfocus and active) の tab の url を取得
+    chrome.tabs.query({'active': true, 'lastFocusedWindow': true}, function (tabs) {
+        url = tabs[0].url;
+    });
+    chrome.storage.local.get("url_list",
+        function(value){url_list = value["url_list"];
+        if(typeof(url_list) == "undefined") url_list = [];
+        //png データの取得と保存
+        store_png(url, url_list);
+    })
+}
+
+//png データの取得と保存
+//jpeg も選択可能だが、pngの方が軽いため
+//url: スクリーンショットを取得する url
+//url_list: スクリーンショット取得済みの url の list
+//stream: png のデータ
+function store_png(url, url_list){
+    //現在の tab のスクリーンショットを取得
     chrome.tabs.captureVisibleTab(
+        //png の指定
         {"format":"png"},
         function(stream) {
-            chrome.storage.local.set({"image01":stream}, function(){})
+            //データの保存(重複する url の管理含む)
+            control_storage(url, url_list, stream);
             //alert(stream); //<-- NULL
             if (!stream) {
               console.error('Error starting tab capture: ' + chrome.runtime.lastError.message || 'UNKNOWN');
@@ -11,4 +50,40 @@ function capture_shot(){
     );
 }
 
-capture_shot();
+//スクリーンショット数が最大値(storage_limit)の時と重複した際の url の検知
+//url: スクリーンショットを取得する url
+//url_list: スクリーンショット取得済みの url の list
+//stream: png のデータ
+function control_storage(url, url_list, stream){
+    //delete_url: 削除する url の発見
+    var index = url_list.indexOf(url);
+    var delete_url;
+    if(index >= 0){
+        delete_url = url_list[index];
+        url_list.splice(index, 1);
+    }
+    else if(url_list.length >= storage_limit){
+        delete_url = url_list[0];
+        url_list.shift();
+    }
+    url_list.push(url);
+    //データの保存
+    store_data(url, url_list, stream, delete_url);
+}
+
+//データの保存
+//url: スクリーンショットを取得する url
+//url_list: スクリーンショット取得済みの url の list
+//stream: png のデータ
+//delete_url: 削除する url
+function store_data(url, url_list, stream, delete_url){
+    //データの削除がある時，その値(delete_url)を更新
+    if(typeof(delete_url) != "undefined"){
+        chrome.storage.local.remove([delete_url],
+            function(){chrome.storage.local.set({[url]:stream, "url_list": url_list}, function(){})})
+    }
+    //データの削除がない時
+    else{
+        chrome.storage.local.set({[url]:stream, "url_list": url_list}, function(){})
+    }
+}

--- a/controllers/images/get_capture_event.js
+++ b/controllers/images/get_capture_event.js
@@ -1,0 +1,11 @@
+//capture_shot.js へのイベントの送信
+//正しくは、capture_event という message で送っているだけでファイル指定はない
+chrome.runtime.sendMessage(
+    {
+        message: "capture_event"
+    },
+    function(response) {
+        //console.log(response);
+        //alert(response);
+    }
+);

--- a/controllers/images/get_images.js
+++ b/controllers/images/get_images.js
@@ -1,7 +1,33 @@
+//local に保存してある screenshot の取り出しと
+//html 形式への出力を行う
+
+//取得したスクリーンショットの取得
+//url_list: スクリーンショット取得済みの url の list
 function get_images(){
-    chrome.storage.local.get("image01", function(value){
-        console.log(value.image01)
-        document.write('<img src='+value.image01+' width="100%" alt="Red dot" />');
+    var url_list;
+    chrome.storage.local.get("url_list",
+        function(value){
+            url_list = value["url_list"];
+            //まだスクリーンショットを取ってない時は実行しない
+            if(typeof(url_list) != "undefined"){
+                get_shot(url_list);
+            }
+        }
+    )
+}
+
+//取得したスクリーンショットを html 形式に
+//url_list: スクリーンショット取得済みの url の list
+function get_shot(url_list){
+    var i;
+    chrome.storage.local.get(url_list, function(value){
+        for(i in url_list){
+            //スクリーンショットを正確に取れていないときは表示しない
+            if(typeof(value[url_list[i]]) != "undefined"){
+                document.write('<p>'+url_list[i]+'</p>')
+                document.write('<img src='+value[url_list[i]]+' width="100%" alt="Red dot" />');
+            }
+        }
     })
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -21,5 +21,11 @@
         ],
         "persistent": false
     },
+    "content_scripts":[
+        {
+            "matches": ["<all_urls>"],
+            "js": ["controllers/images/get_capture_event.js"]
+        }
+    ],
     "content_security_policy": " script-src 'self' 'sha256-VePmQi2Ey76e61vq8bYfhTPpa3kR3k0fkLS2r0oGWPQ='; object-src 'self'"
 }

--- a/test_capture.html
+++ b/test_capture.html
@@ -1,0 +1,15 @@
+<!--
+    スクリーンショットのテストページ
+    history 側との重複を避けるため
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test</title>
+</head>
+<body>
+<h1>TEST PAGE</h1>
+<script type="module" src="controllers/images/get_images.js"></script>
+</body>
+</html>


### PR DESCRIPTION
http へ対応しました

スクリーンショットの表示順は
最新順になっていて、重複は削除しています

申し訳ないんですが
capture_shot.js, get_images.js は共に
1つの関数で書けるところを、あまりにネストしてしまうため
小分けにしています

いくつかの関数で引数が重複しているのはそのためで
通常の関数のように役割が分けられているわけではないです